### PR TITLE
adjust Odata web 2.0 expand command

### DIFF
--- a/redfish_collector.py
+++ b/redfish_collector.py
@@ -286,7 +286,7 @@ class RedfishIventoryCollector:
 
     def _get_system_urls(self):
 
-        systems = self.connect_server(self._urls['Systems_Root']+'?$expand=*')
+        systems = self.connect_server(self._urls['Systems_Root']+'/1')
 
         if not systems:
             logging.error(

--- a/redfish_collector.py
+++ b/redfish_collector.py
@@ -286,7 +286,7 @@ class RedfishIventoryCollector:
 
     def _get_system_urls(self):
 
-        systems = self.connect_server(self._urls['Systems_Root']+'/1')
+        systems = self.connect_server(self._urls['Systems_Root']+'?$expand=.')
 
         if not systems:
             logging.error(


### PR DESCRIPTION
does not work with HPE currently, tested for gen10 and gen11
e.g. 
> 2025-03-04 11:15:20,850 1 redfish_collector.py:229  ERROR     Target node001r-bb563.cc.eu-de-1.cloud.sap: Unable to connect to URL https://10.245.236.4/redfish/v1/Systems?$expand=*
> 2025-03-04 11:15:20,850 1 redfish_collector.py:299  ERROR     Target node001r-bb563.cc.eu-de-1.cloud.sap: No Systems Members found!